### PR TITLE
Delete lock

### DIFF
--- a/modelforge/backends.py
+++ b/modelforge/backends.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Type
+from functools import wraps
 
 import modelforge.configuration as config
 from modelforge.gcs_backend import GCSBackend
@@ -46,6 +47,7 @@ def supply_backend(optional=False):
     real_optional = False if callable(optional) else optional
 
     def supply_backend_inner(func):
+        @wraps(func)
         def wrapped_supply_backend(args):
             log = logging.getLogger(func.__name__)
             if real_optional and not getattr(args, "backend", False):

--- a/modelforge/delete.py
+++ b/modelforge/delete.py
@@ -33,7 +33,6 @@ def delete_model(args: argparse.Namespace, backend: StorageBackend, log: logging
         index["models"].pop(meta["model"])
     else:
         index["models"][meta["model"]].pop(meta["uuid"])
-    with backend.lock():
-        backend.delete_model(meta)
-        log.info("Updating the models index...")
-        backend.upload_index(index)
+    backend.delete_model(meta)
+    log.info("Updating the models index...")
+    backend.upload_index(index)

--- a/modelforge/registry.py
+++ b/modelforge/registry.py
@@ -30,16 +30,15 @@ def publish_model(args: argparse.Namespace, backend: StorageBackend, log: loggin
         log.critical("Failed to load the model: %s: %s" % (type(e).__name__, e))
         return 1
     meta = model.meta
-    with backend.lock():
-        model_url = backend.upload_model(path, meta, args.force)
-        log.info("Uploaded as %s", model_url)
-        log.info("Updating the models index...")
-        index = backend.fetch_index()
-        index["models"].setdefault(meta["model"], {})[meta["uuid"]] = \
-            extract_index_meta(meta, model_url)
-        if args.update_default:
-            index["models"][meta["model"]][Model.DEFAULT_NAME] = meta["uuid"]
-        backend.upload_index(index)
+    model_url = backend.upload_model(path, meta, args.force)
+    log.info("Uploaded as %s", model_url)
+    log.info("Updating the models index...")
+    index = backend.fetch_index()
+    index["models"].setdefault(meta["model"], {})[meta["uuid"]] = \
+        extract_index_meta(meta, model_url)
+    if args.update_default:
+        index["models"][meta["model"]][Model.DEFAULT_NAME] = meta["uuid"]
+    backend.upload_index(index)
 
 
 @supply_backend
@@ -83,6 +82,5 @@ def initialize_registry(args: argparse.Namespace, backend: StorageBackend, log: 
     except FileNotFoundError:
         pass
     # The lock is not needed here, but upload_index() will raise otherwise
-    with backend.lock():
-        backend.upload_index({"models": {}})
+    backend.upload_index({"models": {}})
     log.info("Successfully initialized")

--- a/modelforge/storage_backend.py
+++ b/modelforge/storage_backend.py
@@ -23,12 +23,6 @@ class StorageBackend:
         """
         raise NotImplementedError
 
-    def lock(self):
-        """
-        Returns a scoped object which holds a lock.
-        """
-        raise NotImplementedError
-
     def upload_model(self, path: str, meta: dict, force: bool) -> str:
         """
         Puts the given file to the remote storage.

--- a/modelforge/tests/test_delete.py
+++ b/modelforge/tests/test_delete.py
@@ -1,6 +1,5 @@
 import argparse
 import unittest
-from contextlib import contextmanager
 
 from modelforge.delete import delete_model
 from modelforge.backends import StorageBackend, register_backend
@@ -11,7 +10,6 @@ class FakeBackend(StorageBackend):
 
     NAME = "del"
     index = {"models": {"docfreq": {"default": "2", "1": 1, "2": 2}}}
-    locked = False
     model = [1, 2]
 
     def fetch_model(self, source: str, file: str) -> None:
@@ -20,22 +18,18 @@ class FakeBackend(StorageBackend):
     def fetch_index(self) -> dict:
         return self.index
 
-    @contextmanager
-    def lock(self):
-        FakeBackend.locked = True
-        yield None
-
     def upload_model(self, path: str, meta: dict, force: bool) -> str:
         pass
 
     def upload_index(self, index: dict) -> None:
-        assert self.locked
         self.index = index
 
     def delete_model(self, meta: dict):
-        assert self.locked
         if len(self.model):
             self.model.pop()
+
+    def create_bucket(self):
+        pass
 
 
 class DeleteTests(unittest.TestCase):


### PR DESCRIPTION
So following last PR, this:
- deletes lock method from `StorageBackend` class
- replaces connection to bucket in `GCSBackend` previously done in lock with a `create_bucket` method called by delete and upload function -> no more _bucket attribute, 
- adds @wraps to `supply_backend` decorator
(- update tests)