### PR TITLE
Add git based index [part 2]

### DIFF
--- a/modelforge/configuration.py
+++ b/modelforge/configuration.py
@@ -6,6 +6,7 @@ import traceback
 VENDOR = os.getenv("MODELFORGE_VENDOR", None)
 BACKEND = os.getenv("MODELFORGE_BACKEND", None)
 BACKEND_ARGS = os.getenv("MODELFORGE_BACKEND_ARGS", "")
+DEFAULT_REPO = os.getenv("MODELFORGE_DEFAULT_REPO", "")
 
 OVERRIDE_FILE = "modelforgecfg.py"
 

--- a/modelforge/index.py
+++ b/modelforge/index.py
@@ -1,0 +1,196 @@
+import os
+import json
+import shutil
+import logging
+import requests
+import humanize
+
+from jinja2 import Template
+from dulwich import porcelain as git
+from dulwich.repo import Repo
+from dulwich.errors import HangupException, GitProtocolError, NotGitRepository
+
+from modelforge.configuration import DEFAULT_REPO
+from modelforge.meta import extract_index_meta
+from modelforge.models import Model
+
+INDEX_FILE = "index.json"  #: Models repository index file name.
+DEFAULT_PROTOCOL = "https"
+DEFAULT_DOMAIN = "github.com"
+DEFAULT_CACHE = os.path.expanduser("~/.cache")
+REMOTE_URL = "%s://%s%s/%s"  #: Remote repo url
+README_KEYS = {"default", "description", "code"}
+
+
+class GitIndex:
+
+    COMMIT_MESSAGES = {
+        "initilialize": "Initialize a new Modelforge index",
+        "delete": "Delete {model_type}/{model_uuid}",
+        "add": "Add {model_type}/{model_uuid}",
+    }
+
+    def __init__(self, protocol: str=DEFAULT_PROTOCOL, domain: str=DEFAULT_DOMAIN,
+                 repo: str=DEFAULT_REPO, username: str="", password: str="",
+                 cache: str=DEFAULT_CACHE, log_level: int=logging.INFO):
+        """
+        Initializes a new instance of :class:`GitIndex`.
+
+        :param protocol: Protocol to use, either http(s), tcp or ssh
+        :param domain: Domain name, defaults to github.com
+        :param repo: Remote repo to use for index, defaults to the one set by configuration.py file
+        :param username: Username for credentials if protocol is not ssh
+        :param password: Password for credentials if protocol is not ssh
+        :param log_level: The logging level of this instance.
+        :raise ValueError: If missing credential, incorrect domain or incorrect credentials
+        """
+        self._log = logging.getLogger("GitIndex")
+        self._log.setLevel(log_level)
+        self.repo = repo
+        self.cached_repo = os.path.join(cache, repo)
+        auth = ""
+        if protocol in ("ssh", "git+ssh"):
+            auth += "git@"
+        elif username and password:
+            auth += username + ":" + password + "@"
+        elif username or password:
+            raise ValueError("Both username and password must be supplied to access git with "
+                             "credentials.")
+        self.remote_url = REMOTE_URL % (protocol, auth, domain, repo)
+        self.index = None
+        try:
+            self.fetch_index()
+        except NotGitRepository as e:
+            raise ValueError("Repository does not exist: %s" % e) from e
+        except HangupException as e:
+            raise ValueError("Check SSH is configured, or connection is stable: %s" % e) from e
+        except GitProtocolError as e:
+            raise ValueError("%s: %s\nCheck your Git credentials." % (type(e), e))
+        self.models = self.index["models"]
+
+    def fetch_index(self):
+        os.makedirs(os.path.dirname(self.cached_repo), exist_ok=True)
+        if not os.path.exists(self.cached_repo):
+            self._log.warning("Index not found, caching %s in %s", (self.repo, self.cached_repo))
+            git.clone(self.remote_url, self.cached_repo, checkout=True)
+        else:
+            self._log.info("Index is cached")
+            if self._are_local_and_remote_heads_different():
+                self._log.info("Cached index is not up to date, pulling %s", self. repo)
+                git.pull(self.cached_repo, self.remote_url)
+        with open(os.path.join(self.cached_repo, INDEX_FILE), encoding="utf-8") as _in:
+            self.index = json.load(_in)
+
+    def remove_model(self, model_uuid: str) -> dict:
+        model_type = None
+        for key, val in self.models.items():
+            if model_uuid in val:
+                self._log.info("Found %s among %s models.", (model_uuid, key))
+                model_type = key
+                break
+        if model_type is None:
+            raise ValueError("Model not found, aborted.")
+        node = self.models[model_type]
+        if Model.DEFAULT_NAME in node and model_uuid == node[Model.DEFAULT_NAME]:
+            self._log.info("Model is set as default, removing from index ...")
+            node.pop(Model.DEFAULT_NAME)
+        model_directory = os.path.join(self.cached_repo, model_type)
+
+        if len(node) == 3:
+            self.models.pop(model_type)
+            shutil.rmtree(model_directory)
+        else:
+            node.pop(model_uuid)
+            os.remove(os.path.join(model_directory, model_uuid + ".md"))
+        return {"model_type": model_type, "model_uuid": model_uuid}
+
+    def add_model(self, model_type: str, model_uuid: str, base_meta: dict, extra_meta: dict,
+                  model_url: str, template_model: Template, update_default: bool=False):
+        self.models.setdefault(model_type, {})[model_uuid] = \
+            extract_index_meta(base_meta, model_url)
+        node = self.models[model_type]
+        if update_default or len(node) == 1:
+            node[Model.DEFAULT_NAME] = model_uuid
+        if update_default or len(node) == 2:
+            for name in ("code", "description"):
+                node[name] = extra_meta[name]
+        for key, val in extra_meta["model"].items():
+            node[model_uuid].setdefault(key, val)
+        model_directory = os.path.join(self.cached_repo, model_type)
+        os.makedirs(model_directory, exist_ok=True)
+        model = os.path.join(model_directory, model_uuid + ".md")
+        if os.path.exists(model):
+            os.remove(model)
+        response = requests.get(model_url, stream=True)
+        size = humanize.naturalsize(int(response.headers["content-length"]))
+        links = {}
+        for name, items in self.models.items():
+            for uuid in items:
+                if uuid in extra_meta["model"]["dependencies"]:
+                    links[uuid] = os.path.join("/", name, "%s.md" % uuid)
+        with open(model, "w") as fout:
+            fout.write(template_model.render(base=base_meta, details=extra_meta, links=links,
+                       size=size))
+        self._log.info("Added %s", model)
+
+    def update_readme(self, template_readme: Template):
+        readme = os.path.join(self.cached_repo, "README.md")
+        if os.path.exists(readme):
+            os.remove(readme)
+        links = {}
+        for name, items in self.models.items():
+            for key in items:
+                if key in README_KEYS:
+                    continue
+                links[key] = os.path.join("/", name, "%s.md" % key)
+
+        with open(readme, "w") as fout:
+            fout.write(
+                template_readme.render(models=self.models, links=links, metakeys=README_KEYS))
+        self._log.info("Updated %s", readme)
+
+    def initialize_index(self):
+        for filename in os.listdir(self.cached_repo):
+            if ".git" in filename:
+                continue
+            path = os.path.join(self.cached_repo, filename)
+            if os.path.isfile(path):
+                os.remove(path)
+            elif os.path.isdir(path):
+                shutil.rmtree(path)
+        self.index = {"models": {}}
+
+    def upload_index(self, cmd: str, meta: dict):
+        index = os.path.join(self.cached_repo, INDEX_FILE)
+        if os.path.exists(index):
+            os.remove(index)
+        self._log.info("Writing the new index.json ...")
+        with open(index, "w") as _out:
+            json.dump(self.index, _out)
+        # implementation of git add --all is pretty bad, changing directory is the easiest way
+        os.chdir(self.cached_repo)
+        git.add()
+        git.commit(message=self.COMMIT_MESSAGES[cmd].format(**meta))
+        self._log.info("Pushing the updated index ...")
+        # TODO: change when https://github.com/dulwich/dulwich/issues/631 gets addressed
+        git.push(self.cached_repo, self.remote_url, b"master")
+        if self._are_local_and_remote_heads_different():
+            raise ValueError("Push has failed")
+
+    def load_template(self, template: str) -> Template:
+        env = dict(trim_blocks=True, lstrip_blocks=True, keep_trailing_newline=False)
+        jinja2_ext = ".jinja2"
+        if not template.endswith(jinja2_ext):
+            raise ValueError("Template file name must end with %s" % jinja2_ext)
+        if not template[:-len(jinja2_ext)].endswith(".md"):
+            raise ValueError("Template file should be a Markdown file.")
+        with open(template, encoding="utf-8") as fin:
+            template_obj = Template(fin.read(), **env)
+        template_obj.filename = template
+        self._log.info("Loaded %s", template)
+        return template_obj
+
+    def _are_local_and_remote_heads_different(self):
+        local_head = Repo(self.cached_repo).head()
+        remote_head = git.ls_remote(self.remote_url)[b"HEAD"]
+        return local_head != remote_head

--- a/modelforge/tests/fake_dulwich.py
+++ b/modelforge/tests/fake_dulwich.py
@@ -1,0 +1,88 @@
+import os
+import json
+from copy import deepcopy
+from dulwich.errors import HangupException, GitProtocolError, NotGitRepository
+import modelforge.index as ind
+
+
+def clone(remote_url, cached_repo, checkout=True):
+    if "bad-url-1" in remote_url:
+        raise HangupException
+    if "bad-url-2" in remote_url:
+        raise GitProtocolError
+    if "bad-url-3" in remote_url:
+        raise NotGitRepository
+    os.makedirs(cached_repo, exist_ok=True)
+    with open(os.path.join(cached_repo, ind.INDEX_FILE), "w") as _out:
+        json.dump(FakeRepo.index, _out)
+    df_dir = os.path.join(cached_repo, "docfreq")
+    os.mkdir(df_dir)
+    with open(os.path.join(df_dir, "12345678-9abc-def0-1234-56789abcdef0.md"), "w") as _out:
+        _out.write("test")
+    with open(os.path.join(df_dir, "1e3da42a-28b6-4b33-94a2-a5671f4102f4.md"), "w") as _out:
+        _out.write("test")
+    FakeRepo.remote_url = remote_url
+    FakeRepo.checkout = checkout
+
+
+def pull(remote_url, cached_repo):
+    FakeRepo.remote_head = "0"
+    FakeRepo.pulled = True
+
+
+def add():
+    FakeRepo.added = True
+
+
+def ls_remote(remote_url):
+    return {b"HEAD": "0"}
+
+
+def commit(message):
+    FakeRepo.message = message
+
+
+def push(cached_repo, remote_url, branch):
+    FakeRepo.pushed = True
+
+
+class FakeRepo:
+    remote_head = "0"
+    uploaded_index = None
+    checkout = False
+    pulled = False
+    added = False
+    message = None
+    pushed = False
+    remote_url = None
+    default_index = {
+        "models": {
+            "docfreq": {
+                "code": "%s",
+                "description": "",
+                "default": "12345678-9abc-def0-1234-56789abcdef0",
+                "12345678-9abc-def0-1234-56789abcdef0": {
+                    "url": "https://xxx",
+                    "created_at": "13:00"},
+                "1e3da42a-28b6-4b33-94a2-a5671f4102f4": {
+                    "url": "https://xxx",
+                    "created_at": "13:00"}}}}
+    index = deepcopy(default_index)
+
+    def __init__(self, cached_repo):
+        pass
+
+    def head(self):
+        return FakeRepo.remote_head
+
+    @classmethod
+    def reset(cls):
+        cls.uploaded_index = None
+        cls.remote_head = "0"
+        cls.checkout = False
+        cls.pulled = False
+        cls.added = False
+        cls.message = None
+        cls.pushed = False
+        cls.remote_url = None
+        cls.index = deepcopy(cls.default_index)

--- a/modelforge/tests/model.md
+++ b/modelforge/tests/model.md
@@ -1,0 +1,22 @@
+# 
+
+
+
+Example:
+
+```
+"92609e70-f79c-46b5-8419-55726e873cfc"
+```
+
+### References
+
+
+|    |    |
+|:---|:---|
+| ID       | 92609e70-f79c-46b5-8419-55726e873cfc |
+| Uploaded | 13:00 |
+| Version  | 1.0.0 |
+| File     | https://xxx |
+| Size     | 4 Bytes |
+| License  | [](undecided) |
+

--- a/modelforge/tests/readme.md
+++ b/modelforge/tests/readme.md
@@ -1,0 +1,16 @@
+source{d} MLonCode models
+=========================
+
+## docfreq
+
+
+Example:
+
+```
+model_path
+```
+
+2 models:
+
+* <default> [12345678-9abc-def0-1234-56789abcdef0](/docfreq/12345678-9abc-def0-1234-56789abcdef0.md) 
+*  [1e3da42a-28b6-4b33-94a2-a5671f4102f4](/docfreq/1e3da42a-28b6-4b33-94a2-a5671f4102f4.md) 

--- a/modelforge/tests/test_index.py
+++ b/modelforge/tests/test_index.py
@@ -1,0 +1,258 @@
+import os
+import json
+import shutil
+import unittest
+import modelforge.index as ind
+
+from modelforge.tests import fake_dulwich as fake_git
+from modelforge.tests.fake_dulwich import FakeRepo
+from modelforge.tests.fake_requests import FakeRequests
+
+
+class GitIndexTests(unittest.TestCase):
+    cached_path = "/tmp/modelforge-test-cache"
+    default_repo = "src-d/models"
+
+    def clear(self):
+        if os.path.exists(self.cached_path):
+            shutil.rmtree(os.path.expanduser(self.cached_path))
+
+    def setUp(self):
+        fake_git.FakeRepo.reset()
+        ind.Repo = FakeRepo
+        ind.git = fake_git
+
+    def tearDown(self):
+        self.clear()
+        from dulwich.repo import Repo
+        ind.Repo = Repo
+        from dulwich import porcelain as git
+        ind.git = git
+
+    def test_init(self):
+        git_index = ind.GitIndex(repo=self.default_repo, cache=self.cached_path)
+        self.assertTrue(FakeRepo.checkout)
+        self.assertEqual(FakeRepo.remote_url, "https://github.com/src-d/models")
+        self.assertTrue(os.path.exists("/tmp/modelforge-test-cache/src-d/models/index.json"))
+        self.assertEqual(git_index.index, FakeRepo.index)
+        self.clear()
+        FakeRepo.reset()
+        ind.GitIndex(repo=self.default_repo, protocol="http", cache=self.cached_path)
+        self.assertEqual(FakeRepo.remote_url, "http://github.com/src-d/models")
+        self.clear()
+        FakeRepo.reset()
+        ind.GitIndex(repo=self.default_repo, protocol="ssh", cache=self.cached_path)
+        self.assertEqual(FakeRepo.remote_url, "ssh://git@github.com/src-d/models")
+        self.clear()
+        FakeRepo.reset()
+        ind.GitIndex(repo=self.default_repo, protocol="git+ssh", cache=self.cached_path)
+        self.assertEqual(FakeRepo.remote_url, "git+ssh://git@github.com/src-d/models")
+        self.clear()
+        FakeRepo.reset()
+        ind.GitIndex(repo=self.default_repo, username="user", password="password",
+                     cache=self.cached_path)
+        self.assertEqual(FakeRepo.remote_url, "https://user:password@github.com/src-d/models")
+        self.clear()
+        FakeRepo.reset()
+        ind.GitIndex(repo=self.default_repo, domain="notgithub.com", cache=self.cached_path)
+        self.assertEqual(FakeRepo.remote_url, "https://notgithub.com/src-d/models")
+        self.clear()
+        FakeRepo.reset()
+        ind.GitIndex(repo="not/src-d/models", cache=self.cached_path)
+        self.assertEqual(FakeRepo.remote_url, "https://github.com/not/src-d/models")
+        self.clear()
+        FakeRepo.reset()
+        succeeded = True
+        try:
+            ind.GitIndex(repo="bad-url-1", cache=self.cached_path)
+            succeeded = False
+        except ValueError:
+            self.assertTrue(succeeded)
+        try:
+            ind.GitIndex(repo="bad-url-2", cache=self.cached_path)
+            succeeded = False
+        except ValueError:
+            self.assertTrue(succeeded)
+        try:
+            ind.GitIndex(repo="bad-url-3", cache=self.cached_path)
+            succeeded = False
+        except ValueError:
+            self.assertTrue(succeeded)
+        try:
+            ind.GitIndex(repo=self.default_repo, username="no-password", cache=self.cached_path)
+            succeeded = False
+        except ValueError:
+            self.assertTrue(succeeded)
+        try:
+            ind.GitIndex(repo=self.default_repo, password="no-username", cache=self.cached_path)
+            succeeded = False
+        except ValueError:
+            self.assertTrue(succeeded)
+
+    def test_fetch(self):
+        git_index = ind.GitIndex(repo=self.default_repo, cache=self.cached_path)
+        git_index.fetch_index()
+        self.assertFalse(FakeRepo.pulled)
+        FakeRepo.remote_head = "1"
+        git_index.fetch_index()
+        self.assertTrue(FakeRepo.pulled)
+
+    def test_remove(self):
+        git_index = ind.GitIndex(repo=self.default_repo, cache=self.cached_path)
+        success = False
+        try:
+            git_index.remove_model("fake_uuid")
+        except ValueError:
+            success = True
+        self.assertTrue(success)
+        git_index.remove_model("1e3da42a-28b6-4b33-94a2-a5671f4102f4")
+        self.assertNotIn("1e3da42a-28b6-4b33-94a2-a5671f4102f4",
+                         git_index.models["docfreq"])
+        self.assertIn("12345678-9abc-def0-1234-56789abcdef0", git_index.models["docfreq"])
+        self.assertIn("default", git_index.models["docfreq"])
+        self.assertFalse(os.path.exists("/tmp/modelforge-test-cache/src-d/models/docfreq/"
+                                        "1e3da42a-28b6-4b33-94a2-a5671f4102f4.md"))
+        self.assertTrue(os.path.exists("/tmp/modelforge-test-cache/src-d/models/docfreq/"
+                                       "12345678-9abc-def0-1234-56789abcdef0.md"))
+        self.clear()
+        FakeRepo.reset()
+        git_index = ind.GitIndex(repo=self.default_repo, cache=self.cached_path)
+        git_index.remove_model("12345678-9abc-def0-1234-56789abcdef0")
+        self.assertTrue(os.path.exists("/tmp/modelforge-test-cache/src-d/models/docfreq/"
+                                       "1e3da42a-28b6-4b33-94a2-a5671f4102f4.md"))
+        self.assertFalse(os.path.exists("/tmp/modelforge-test-cache/src-d/models/docfreq/"
+                                        "12345678-9abc-def0-1234-56789abcdef0.md"))
+        self.assertIn("1e3da42a-28b6-4b33-94a2-a5671f4102f4", git_index.models["docfreq"])
+        self.assertNotIn("12345678-9abc-def0-1234-56789abcdef0", git_index.models["docfreq"])
+        self.assertNotIn("default", git_index.models["docfreq"])
+        git_index.remove_model("1e3da42a-28b6-4b33-94a2-a5671f4102f4")
+        self.assertNotIn("docfreq", git_index.models)
+        self.assertFalse(os.path.exists("/tmp/modelforge-test-cache/src-d/models/docfreq/"))
+
+    def test_add(self):
+        def router(url):
+            return url
+
+        ind.requests = FakeRequests(router)
+        git_index = ind.GitIndex(repo=self.default_repo, cache=self.cached_path)
+        base_meta = {"model": "docfreq", "uuid": "92609e70-f79c-46b5-8419-55726e873cfc",
+                     "url": "https://xxx", "created_at": "13:00", "version": [1, 0, 0],
+                     "dependencies": []}
+        with open(os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                               "templates/template_meta.json"), "r") as _in:
+            extra_meta = json.load(_in)
+        template = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                                "templates/template_model.md.jinja2")
+        template_obj = git_index.load_template(template)
+        git_index.add_model("docfreq", "92609e70-f79c-46b5-8419-55726e873cfc", base_meta,
+                            extra_meta, "", template_obj)
+        self.assertIn("92609e70-f79c-46b5-8419-55726e873cfc", git_index.index["models"]["docfreq"])
+        self.assertNotEqual(git_index.index["models"]["docfreq"]["default"],
+                            "92609e70-f79c-46b5-8419-55726e873cfc")
+        self.assertTrue(os.path.exists("/tmp/modelforge-test-cache/src-d/models/docfreq/"
+                                       "92609e70-f79c-46b5-8419-55726e873cfc.md"))
+        git_index.add_model("docfreq", "92609e70-f79c-46b5-8419-55726e873cfc", base_meta,
+                            extra_meta, "", template_obj, update_default=True)
+        self.assertIn("92609e70-f79c-46b5-8419-55726e873cfc", git_index.index["models"]["docfreq"])
+        self.assertEqual(git_index.index["models"]["docfreq"]["default"],
+                         "92609e70-f79c-46b5-8419-55726e873cfc")
+        self.assertTrue(os.path.exists("/tmp/modelforge-test-cache/src-d/models/docfreq/"
+                                       "92609e70-f79c-46b5-8419-55726e873cfc.md"))
+        base_meta.update({"model": "bow"})
+        git_index.add_model("bow", "92609e70-f79c-46b5-8419-55726e873cfc", base_meta, extra_meta,
+                            "test", template_obj)
+        self.assertIn("92609e70-f79c-46b5-8419-55726e873cfc", git_index.index["models"]["bow"])
+        self.assertEqual(git_index.index["models"]["bow"]["default"],
+                         "92609e70-f79c-46b5-8419-55726e873cfc")
+        model_path = "/tmp/modelforge-test-cache/src-d/models/bow/" \
+                     "92609e70-f79c-46b5-8419-55726e873cfc.md"
+        self.assertTrue(os.path.exists(model_path))
+        with open(model_path) as _in:
+            model = _in.read()
+        with open(os.path.join(os.path.dirname(__file__), "model.md")) as _in:
+            real_model = _in.read()
+        self.assertEqual(model, real_model)
+        import requests
+        ind.requests = requests
+
+    def test_readme(self):
+        git_index = ind.GitIndex(repo=self.default_repo, cache=self.cached_path)
+        template = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                                "templates/template_readme.md.jinja2")
+        template = git_index.load_template(template)
+        git_index.update_readme(template)
+        readme_path = "/tmp/modelforge-test-cache/src-d/models/README.md"
+        self.assertTrue(os.path.exists(readme_path))
+        with open(readme_path) as _in:
+            readme = _in.read()
+        with open(os.path.join(os.path.dirname(__file__), "readme.md")) as _in:
+            real_readme = _in.read()
+        self.assertEqual(readme, real_readme)
+
+    def test_upload_init(self):
+        git_index = ind.GitIndex(repo=self.default_repo, cache=self.cached_path)
+        fake_index = {"test": "test", "models": {}}
+        git_index.index = fake_index
+        git_index.models = {}
+        git_index.upload_index("initilialize", {})
+        self.assertTrue(os.path.exists("/tmp/modelforge-test-cache/src-d/models/index.json"))
+        git_index.fetch_index()
+        self.assertEqual(fake_index, git_index.index)
+        self.assertTrue(FakeRepo.added)
+        self.assertEqual(FakeRepo.message, "Initialize a new Modelforge index")
+        self.assertTrue(FakeRepo.pushed)
+
+    def test_upload_add(self):
+        git_index = ind.GitIndex(repo=self.default_repo, cache=self.cached_path)
+        fake_index = {"test": "test", "models": {}}
+        git_index.index = fake_index
+        git_index.models = {}
+        git_index.upload_index("add", {"model_type": "a", "model_uuid": "b"})
+        self.assertTrue(os.path.exists("/tmp/modelforge-test-cache/src-d/models/index.json"))
+        git_index.fetch_index()
+        self.assertEqual(fake_index, git_index.index)
+        self.assertTrue(FakeRepo.added)
+        self.assertEqual(FakeRepo.message, "Add a/b")
+        self.assertTrue(FakeRepo.pushed)
+
+    def test_upload_delete(self):
+        git_index = ind.GitIndex(repo=self.default_repo, cache=self.cached_path)
+        fake_index = {"test": "test", "models": {}}
+        git_index.index = fake_index
+        git_index.models = {}
+        git_index.upload_index("delete", {"model_type": "a", "model_uuid": "b"})
+        self.assertTrue(os.path.exists("/tmp/modelforge-test-cache/src-d/models/index.json"))
+        git_index.fetch_index()
+        self.assertEqual(fake_index, git_index.index)
+        self.assertTrue(FakeRepo.added)
+        self.assertEqual(FakeRepo.message, "Delete a/b")
+        self.assertTrue(FakeRepo.pushed)
+
+    def test_template(self):
+        git_index = ind.GitIndex(repo=self.default_repo, cache=self.cached_path)
+        succeeded = True
+        try:
+            git_index.load_template("fake.jinj4")
+            succeeded = False
+        except ValueError:
+            self.assertTrue(succeeded)
+        try:
+            git_index.load_template("fake.jinja2")
+            succeeded = False
+        except ValueError:
+            self.assertTrue(succeeded)
+        template = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                                "templates/template_readme.md.jinja2")
+        template_obj = git_index.load_template(template)
+        self.assertEqual(template_obj.render({"models": {}}),
+                         "source{d} MLonCode models\n=========================\n")
+
+    def test_initialize_index(self):
+        git_index = ind.GitIndex(repo=self.default_repo, cache=self.cached_path)
+        git_index.initialize_index()
+        self.assertEqual(git_index.index, {"models": {}})
+        self.assertListEqual(os.listdir("/tmp/modelforge-test-cache/src-d/models/"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The class representing the index. We use dulwich to manage a cached repo that serves as a local copy of the git repo -> dulwich implements clone/pull/commit/push etc. 

- fetch_index: clones the remote index, updates it if necessary, and loads `index.json`in the index class attribute (python dict) -> called at init
- remove_model: removes a model from the index and cached repo -> called in delete
- add_model: adds a model to the index and cached repo --> called in publish
- update_readme: removes cached readme and rewrites it -> called in both publish and delete
- initialize_index: destructively resets the index, cache is purged -> used in init
- upload_index: pushed cached index to git, after overwritting `index.json` with the current value of the class -> used in init, delete and publish
- load_template -> helper function to load a jinja2 template, used both in add_model and update_readme 

At init uses regex to check the given remote_repo, username and password args have a correct format, if either is missing there is no auth in the url. Also initializes commit message and calls fetch index.
