### PR TITLE
[MINOR] Typos, renaming, other stuff

### DIFF
--- a/modelforge/index.py
+++ b/modelforge/index.py
@@ -155,7 +155,7 @@ class GitIndex:
             fout.write(template_readme.render(models=self.models, meta=self.meta, links=links))
         self._log.info("Updated %s", readme)
 
-    def initialize_index(self):
+    def reset(self):
         for filename in os.listdir(self.cached_repo):
             if filename.startswith(".git"):
                 continue
@@ -166,7 +166,7 @@ class GitIndex:
                 shutil.rmtree(path)
         self.contents = {"models": {}, "meta": {}}
 
-    def upload_index(self, cmd: str, meta: dict):
+    def upload(self, cmd: str, meta: dict):
         index = os.path.join(self.cached_repo, INDEX_FILE)
         if os.path.exists(index):
             os.remove(index)

--- a/modelforge/registry.py
+++ b/modelforge/registry.py
@@ -27,10 +27,10 @@ def initialize_registry(args: argparse.Namespace, backend: StorageBackend, log: 
     except ExistingBackendError:
         return 1
 
-    log.info("Deleting content of index ...")
-    backend.index.initialize_index()
+    log.info("Resetting the index ...")
+    backend.index.reset()
     try:
-        backend.index.upload_index("initilialize", {})
+        backend.index.upload("initialize", {})
     except ValueError:
         return 1
     log.info("Successfully initialized")
@@ -96,7 +96,7 @@ def publish_model(args: argparse.Namespace, backend: StorageBackend, log: loggin
                             args.update_default)
     backend.index.update_readme(template_readme)
     try:
-        backend.index.upload_index("add", base_meta)
+        backend.index.upload("add", base_meta)
     except ValueError:  # TODO: replace with PorcelainError, see related TODO in index.py:181
         return 1
     log.info("Successfully published.")
@@ -144,7 +144,7 @@ def delete_model(args: argparse.Namespace, backend: StorageBackend, log: logging
     backend.delete_model(meta)
     log.info("Updating the models index...")
     try:
-        backend.index.upload_index("delete", meta)
+        backend.index.upload("delete", meta)
     except ValueError:  # TODO: replace with PorcelainError
         return 1
     log.info("Successfully deleted.")

--- a/modelforge/tests/test_index.py
+++ b/modelforge/tests/test_index.py
@@ -280,7 +280,7 @@ class GitIndexTests(unittest.TestCase):
         git_index = ind.GitIndex(index_repo=self.default_url, cache=self.cached_path)
         with open(os.path.join(git_index.cached_repo, ".gitignore"), "w") as _out:
             _out.write("nothing")
-        git_index.initialize_index()
+        git_index.reset()
         empty_index = {"models": {}, "meta": {}}
         self.assertDictEqual(empty_index, git_index.contents)
         self.assertTrue(os.path.exists(git_index.cached_repo))
@@ -288,21 +288,21 @@ class GitIndexTests(unittest.TestCase):
 
     def test_upload_add(self):
         git_index = ind.GitIndex(index_repo=self.default_url, cache=self.cached_path)
-        git_index.upload_index("add", {"model": "a", "uuid": "b"})
+        git_index.upload("add", {"model": "a", "uuid": "b"})
         self.assertTrue(fake_git.FakeRepo.added)
         self.assertEqual(fake_git.FakeRepo.message, "Add a/b")
         self.assertTrue(fake_git.FakeRepo.pushed)
 
     def test_upload_delete(self):
         git_index = ind.GitIndex(index_repo=self.default_url, cache=self.cached_path)
-        git_index.upload_index("delete", {"model": "a", "uuid": "b"})
+        git_index.upload("delete", {"model": "a", "uuid": "b"})
         self.assertTrue(fake_git.FakeRepo.added)
         self.assertEqual(fake_git.FakeRepo.message, "Delete a/b")
         self.assertTrue(fake_git.FakeRepo.pushed)
 
     def test_upload_init(self):
         git_index = ind.GitIndex(index_repo=self.default_url, cache=self.cached_path)
-        git_index.upload_index("initilialize", {})
+        git_index.upload("initilialize", {})
         self.assertTrue(fake_git.FakeRepo.added)
         self.assertEqual(fake_git.FakeRepo.message, "Initialize a new Modelforge index")
         self.assertTrue(fake_git.FakeRepo.pushed)
@@ -312,7 +312,7 @@ class GitIndexTests(unittest.TestCase):
         fake_git.FakeRepo.reset(self.default_index, head="1")
         succeeded = True
         try:
-            git_index.upload_index("initilialize", {})
+            git_index.upload("initilialize", {})
             succeeded = False
         except ValueError:
             pass


### PR DESCRIPTION
Before I forget to address the last somments on the PR, here it is.

I'm not sure it is best to add further logs before the `return 1` in registry functions, when there is no log at that point it is because a log has already been prompted in the function where the error happened. Unless you want to add genereic log messages like "failed while uploading the index", etc.