### PR TITLE
Fix typo and init

### DIFF
--- a/modelforge/registry.py
+++ b/modelforge/registry.py
@@ -30,7 +30,7 @@ def initialize_registry(args: argparse.Namespace, backend: StorageBackend, log: 
     log.info("Resetting the index ...")
     backend.index.reset()
     try:
-        backend.index.upload("initialize", {})
+        backend.index.upload("reset", {})
     except ValueError:
         return 1
     log.info("Successfully initialized")

--- a/modelforge/tests/fake_dulwich.py
+++ b/modelforge/tests/fake_dulwich.py
@@ -31,7 +31,7 @@ def pull(remote_url, cached_repo):
     FakeRepo.pulled = True
 
 
-def add():
+def add(cached_repo, paths):
     FakeRepo.added = True
 
 
@@ -39,12 +39,17 @@ def ls_remote(remote_url):
     return {b"HEAD": "0"}
 
 
-def commit(message):
+def commit(cached_repo, message):
     FakeRepo.message = message
 
 
 def push(cached_repo, remote_url, branch):
     FakeRepo.pushed = True
+
+
+def remove(cached_repo, paths):
+    for path in paths:
+        os.remove(path)
 
 
 class FakeRepo:
@@ -61,7 +66,6 @@ class FakeRepo:
     def __init__(self, cached_repo):
         pass
 
-    @property
     def head(self):
         return self._head
 

--- a/modelforge/tests/test_index.py
+++ b/modelforge/tests/test_index.py
@@ -75,62 +75,34 @@ class GitIndexTests(unittest.TestCase):
         self.assertTrue(fake_git.FakeRepo.pulled)
 
     def test_init_errors(self):
-        succeeded = True
-        try:
+        with self.assertRaises(ValueError):
             ind.GitIndex(index_repo="no_protocol", cache=self.cached_path)
-            succeeded = False
-        except ValueError:
-            pass
-        self.assertTrue(succeeded)
-        try:
+
+        with self.assertRaises(ValueError):
             ind.GitIndex(index_repo="badprotocol://github.com", cache=self.cached_path)
-            succeeded = False
-        except ValueError:
-            pass
-        self.assertTrue(succeeded)
-        try:
+
+        with self.assertRaises(ValueError):
             ind.GitIndex(index_repo="http:///nodomain", cache=self.cached_path)
-            succeeded = False
-        except ValueError:
-            pass
-        self.assertTrue(succeeded)
-        try:
+
+        with self.assertRaises(ValueError):
             ind.GitIndex(index_repo="http://nopath.com", cache=self.cached_path)
-            succeeded = False
-        except ValueError:
-            pass
-        self.assertTrue(succeeded)
-        try:
+
+        with self.assertRaises(ValueError):
             ind.GitIndex(index_repo="http://github.com/not-git-repo", cache=self.cached_path)
-            succeeded = False
-        except ValueError:
-            pass
-        self.assertTrue(succeeded)
-        try:
+
+        with self.assertRaises(ValueError):
             ind.GitIndex(index_repo="http://github.com/bad-ssh", cache=self.cached_path)
-            succeeded = False
-        except ValueError:
-            pass
-        self.assertTrue(succeeded)
-        try:
+
+        with self.assertRaises(ValueError):
             ind.GitIndex(index_repo="http://github.com/bad-credentials", cache=self.cached_path)
-            succeeded = False
-        except ValueError:
-            self.assertTrue(succeeded)
-        try:
+
+        with self.assertRaises(ValueError):
             ind.GitIndex(index_repo=self.default_url, username="no-password",
                          cache=self.cached_path)
-            succeeded = False
-        except ValueError:
-            pass
-        self.assertTrue(succeeded)
-        try:
+
+        with self.assertRaises(ValueError):
             ind.GitIndex(index_repo=self.default_url, password="no-username",
                          cache=self.cached_path)
-            succeeded = False
-        except ValueError:
-            pass
-        self.assertTrue(succeeded)
 
     def test_init_variants(self):
         git_index = ind.GitIndex(
@@ -186,12 +158,9 @@ class GitIndexTests(unittest.TestCase):
 
     def test_remove(self):
         git_index = ind.GitIndex(index_repo=self.default_url, cache=self.cached_path)
-        success = False
-        try:
+        with self.assertRaises(ValueError):
             git_index.remove_model("fake_uuid")
-        except ValueError:
-            success = True
-        self.assertTrue(success)
+
         git_index.remove_model("1e3da42a-28b6-4b33-94a2-a5671f4102f4")
         self.assertNotIn("1e3da42a-28b6-4b33-94a2-a5671f4102f4",
                          git_index.models["docfreq"])
@@ -205,7 +174,8 @@ class GitIndexTests(unittest.TestCase):
         git_index.remove_model("12345678-9abc-def0-1234-56789abcdef0")
         self.assertNotIn("docfreq", git_index.models)
         self.assertNotIn("docfreq", git_index.meta)
-        self.assertFalse(os.path.exists("/tmp/modelforge-test-cache/src-d/models/docfreq/"))
+        self.assertFalse(os.path.exists("/tmp/modelforge-test-cache/src-d/models/docfreq/"
+                                        "12345678-9abc-def0-1234-56789abcdef0"))
         self.clear()
         fake_git.FakeRepo.reset(self.default_index)
         git_index = ind.GitIndex(index_repo=self.default_url, cache=self.cached_path)
@@ -284,7 +254,7 @@ class GitIndexTests(unittest.TestCase):
         empty_index = {"models": {}, "meta": {}}
         self.assertDictEqual(empty_index, git_index.contents)
         self.assertTrue(os.path.exists(git_index.cached_repo))
-        self.assertListEqual(os.listdir(git_index.cached_repo), [".gitignore"])
+        self.assertListEqual(sorted(os.listdir(git_index.cached_repo)), [".gitignore", "docfreq"])
 
     def test_upload_add(self):
         git_index = ind.GitIndex(index_repo=self.default_url, cache=self.cached_path)
@@ -302,7 +272,7 @@ class GitIndexTests(unittest.TestCase):
 
     def test_upload_init(self):
         git_index = ind.GitIndex(index_repo=self.default_url, cache=self.cached_path)
-        git_index.upload("initilialize", {})
+        git_index.upload("reset", {})
         self.assertTrue(fake_git.FakeRepo.added)
         self.assertEqual(fake_git.FakeRepo.message, "Initialize a new Modelforge index")
         self.assertTrue(fake_git.FakeRepo.pushed)
@@ -312,7 +282,7 @@ class GitIndexTests(unittest.TestCase):
         fake_git.FakeRepo.reset(self.default_index, head="1")
         succeeded = True
         try:
-            git_index.upload("initilialize", {})
+            git_index.upload("reset", {})
             succeeded = False
         except ValueError:
             pass
@@ -320,19 +290,12 @@ class GitIndexTests(unittest.TestCase):
 
     def test_template(self):
         git_index = ind.GitIndex(index_repo=self.default_url, cache=self.cached_path)
-        succeeded = True
-        try:
+        with self.assertRaises(ValueError):
             git_index.load_template("fake.jinj4")
-            succeeded = False
-        except ValueError:
-            pass
-        self.assertTrue(succeeded)
-        try:
+
+        with self.assertRaises(ValueError):
             git_index.load_template("fake.jinja2")
-            succeeded = False
-        except ValueError:
-            pass
-        self.assertTrue(succeeded)
+
         template_path = os.path.join(self.templates_dir, "template_readme.md.jinja2")
         template = git_index.load_template(template_path)
         self.assertEqual(template.render(meta={}, models={}, links={}),


### PR DESCRIPTION
Just a typo I did not see, there might be a couple of those - btw once everything has been tested for real, i think we should release a new version. However, currently it does not work, because dulwich is bugged:

```
>>> import dulwich.porcelain as git
>>> git .status()
GitStatus(staged={'add': [], 'delete': [], 'modify': []}, unstaged=[b'README.md', b'bow/1e3da42a-28b6-4b33-94a2-a5671f4102f4.md', b'docfreq/f64bacd4-67fb-4c64-8382-399a8e7db52a.md', b'id-split/3fffe6d4-918f-431e-bccf-f3af388b6ed8.md', b'id2vec/92609e70-f79c-46b5-8419-55726e873cfc.md', b'index.json', b'tensorflow-model/74d255c2-8cf9-4b36-9df4-99c05b981c91.md', b'topics/c70a7514-9257-4b33-b468-27a8588d4dfa.md'], untracked=['.gitignore', 'index.json'])
>>> exit()
:) romain ~/.cache/r0mainK/models (k8s: local-gpu) (git: master) $ git status
On branch master
Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	deleted:    README.md
	deleted:    bow/1e3da42a-28b6-4b33-94a2-a5671f4102f4.md
	deleted:    docfreq/f64bacd4-67fb-4c64-8382-399a8e7db52a.md
	deleted:    id-split/3fffe6d4-918f-431e-bccf-f3af388b6ed8.md
	deleted:    id2vec/92609e70-f79c-46b5-8419-55726e873cfc.md
	modified:   index.json
	deleted:    tensorflow-model/74d255c2-8cf9-4b36-9df4-99c05b981c91.md
	deleted:    topics/c70a7514-9257-4b33-b468-27a8588d4dfa.md

no changes added to commit (use "git add" and/or "git commit -a")
```

I will work on it monday, during OSD.