### PR TITLE
More fixes

### DIFF
--- a/modelforge/gcs_backend.py
+++ b/modelforge/gcs_backend.py
@@ -102,7 +102,7 @@ class GCSBackend(StorageBackend):
             self._log.info("Bucket already exists, deleting all content.")
             for blob in bucket.list_blobs():
                 self._log.info("Deleting %s ..." % blob.name)
-                bucket.delete_blob(blob)
+                bucket.delete_blob(blob.name)
         else:
             client.create_bucket(self.bucket_name)
 

--- a/modelforge/index.py
+++ b/modelforge/index.py
@@ -151,8 +151,6 @@ class GitIndex:
             for model_uuid in model_uuids:
                 links[model_type][model_uuid] = os.path.join("/", model_type, "%s.md" % model_uuid)
         with open(readme, "w") as fout:
-            self._log.info(self.meta)
-            self._log.info(self.models)
             fout.write(template_readme.render(models=self.models, meta=self.meta, links=links))
         git.add(self.cached_repo, [readme])
         self._log.info("Updated %s", readme)

--- a/modelforge/meta.py
+++ b/modelforge/meta.py
@@ -37,13 +37,14 @@ def extract_model_meta(base_meta: dict, extra_meta: dict, model_url: str) -> dic
     :param model_url: public URL of the model
     :return: converted dict.
     """
-    default_meta = {"default": base_meta["uuid"], "code": extra_meta["code"],
-                    "description": extra_meta["description"]}
+    meta = {"default": {"default": base_meta["uuid"], "code": extra_meta["code"],
+                        "description": extra_meta["description"]}}
     del base_meta["model"]
     del base_meta["uuid"]
+    meta["model"] = base_meta
+    meta["model"].update(extra_meta["model"])
     response = requests.get(model_url, stream=True)
-    base_meta["size"] = humanize.naturalsize(int(response.headers["content-length"]))
-    base_meta["url"] = model_url
-    base_meta["default"] = default_meta
-    base_meta.update(extra_meta["model"])
-    return base_meta
+    meta["model"]["size"] = humanize.naturalsize(int(response.headers["content-length"]))
+    meta["model"]["url"] = model_url
+    meta["model"]["created_at"] = str(meta["model"]["created_at"])
+    return meta

--- a/modelforge/registry.py
+++ b/modelforge/registry.py
@@ -85,6 +85,7 @@ def publish_model(args: argparse.Namespace, backend: StorageBackend, log: loggin
     log.info("Uploaded as %s", model_url)
     with open(os.path.join(args.meta), encoding="utf-8") as _in:
         extra_meta = json.load(_in)
+    model_type, model_uuid = base_meta["model"], base_meta["uuid"]
     meta = extract_model_meta(base_meta, extra_meta, model_url)
     log.info("Updating the models index...")
     try:
@@ -92,11 +93,10 @@ def publish_model(args: argparse.Namespace, backend: StorageBackend, log: loggin
         template_readme = backend.index.load_template(args.template_readme)
     except ValueError:
         return 1
-    backend.index.add_model(base_meta["model"], base_meta["uuid"], meta, template_model,
-                            args.update_default)
+    backend.index.add_model(model_type, model_uuid, meta, template_model, args.update_default)
     backend.index.update_readme(template_readme)
     try:
-        backend.index.upload("add", base_meta)
+        backend.index.upload("add", {"model": model_type, "uuid": model_uuid})
     except ValueError:  # TODO: replace with PorcelainError, see related TODO in index.py:181
         return 1
     log.info("Successfully published.")

--- a/modelforge/tests/test_meta.py
+++ b/modelforge/tests/test_meta.py
@@ -58,20 +58,21 @@ class MetaTests(unittest.TestCase):
         model_meta = met.extract_model_meta(base_meta, extra_meta, "https://xxx")
         self.assertIsInstance(model_meta, dict)
         self.assertDictEqual(
-            model_meta, {"code": "model_code %s",
-                         "created_at": dt,
-                         "default": {"code": "readme_code %s",
-                                     "default": "12345678-9abc-def0-1234-56789abcdef0",
-                                     "description": "readme_description"},
-                         "dependencies": ["1e3da42a-28b6-4b33-94a2-a5671f4102f4"],
-                         "description": "model_description",
-                         "extra": {"ex": "tra"},
-                         "license": ["", "undecided"],
-                         "parent": "f64bacd4-67fb-4c64-8382-399a8e7db52a",
-                         "references": [["any", "ref"]],
-                         "size": "7 Bytes",
-                         "url": "https://xxx",
-                         "version": [1, 0, 2]})
+            model_meta, {
+                "default": {"code": "readme_code %s",
+                            "default": "12345678-9abc-def0-1234-56789abcdef0",
+                            "description": "readme_description"},
+                "model": {"created_at": dt,
+                          "code": "model_code %s",
+                          "description": "model_description",
+                          "dependencies": ["1e3da42a-28b6-4b33-94a2-a5671f4102f4"],
+                          "extra": {"ex": "tra"},
+                          "license": ["", "undecided"],
+                          "parent": "f64bacd4-67fb-4c64-8382-399a8e7db52a",
+                          "references": [["any", "ref"]],
+                          "size": "7 Bytes",
+                          "url": "https://xxx",
+                          "version": [1, 0, 2], }})
 
 
 def get_path(name):


### PR DESCRIPTION
@vmarkovtsev a couple more minor changes

- delete_blob method for GCS backends takes the blob name as arg, not the blob in `gcs_backend.py`
- forgot to take out ugly loggings of dicts I used for debug in `index.py`
- small change in metadata extraction
