### PR TITLE
Add DCO

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ BACKEND = "gcs"  # type of backend to use
 BACKEND_ARGS = "bucket='user_bucket.models',credentials='key.json'"  # all backend arguments 
 INDEX_REPO = "https://github.com/user/models"  # git repo for the index
 CACHE_DIR = "~/.cache/modelforge"  # default cache to use for the index
+ALWAYS_SIGNOFF = True  # whether to add a DCO line on each commit message
 ```
 
 

--- a/doc/cmd.md
+++ b/doc/cmd.md
@@ -125,6 +125,8 @@ containing your private key if you are running the `init`, `publish` or `delete`
 
 - `--cache`: Path to the cache where a copy of the git based index will be stored, defaults to 
 `~/.cache`.
+- `-s`/`--signoff`: Whether to add a [DCO](http://developercertificate.org/) to your commit 
+message, if the registry is modified.
 
 __TCP/HTTPS:__
 

--- a/modelforge/__main__.py
+++ b/modelforge/__main__.py
@@ -32,6 +32,12 @@ def main():
                        help="Url of the remote Git repository.")
         p.add_argument("--cache", default=None,
                        help="Path to the folder where the Git repository will be cached.")
+        p.add_argument("-s", "--signoff", action="store_true",
+                       help="Add Signed-off-by line by the committer at the end of the commit log "
+                            "message. The meaning of a signoff depends on the project, but it "
+                            "typically certifies that committer has the rights to submit this work"
+                            " under the same license and agrees to a Developer Certificate of "
+                            "Origin (see http://developercertificate.org/ for more information).")
 
     def add_templates_args(p):
         p.add_argument(

--- a/modelforge/backends.py
+++ b/modelforge/backends.py
@@ -55,7 +55,7 @@ def supply_backend(optional: bool =False, init: bool=False):
             try:
                 git_index = GitIndex(index_repo=args.index_repo, username=args.username,
                                      password=args.password, cache=args.cache, init=init,
-                                     log_level=args.log_level)
+                                     signoff=args.signoff, log_level=args.log_level)
             except ValueError:
                 return 1
 

--- a/modelforge/configuration.py
+++ b/modelforge/configuration.py
@@ -8,6 +8,7 @@ BACKEND = os.getenv("MODELFORGE_BACKEND", None)
 BACKEND_ARGS = os.getenv("MODELFORGE_BACKEND_ARGS", "")
 INDEX_REPO = os.getenv("MODELFORGE_INDEX_REPO", "")
 CACHE_DIR = os.getenv("MODELFORGE_CACHE_DIR", os.path.expanduser("~/.cache"))
+ALWAYS_SIGNOFF = os.getenv("MODELFORGE_ALWAYS_SIGNOFF", False)
 
 OVERRIDE_FILE = "modelforgecfg.py"
 

--- a/modelforge/tests/modelforgecfg.py
+++ b/modelforge/tests/modelforgecfg.py
@@ -1,3 +1,4 @@
 VENDOR = "test"
 BACKEND = "gcs"
 BACKEND_ARGS = "bucket=models.cdn.srcd.run,credentials="
+ALWAYS_SIGNOFF = True

--- a/modelforge/tests/test_backends.py
+++ b/modelforge/tests/test_backends.py
@@ -100,7 +100,7 @@ class BackendTests(unittest.TestCase):
 
         self.assertIsNone(test_optional(argparse.Namespace(
             index_repo=self.default_url, username="", password="", cache=self.cached_path,
-            log_level="WARNING")))
+            signoff=None, log_level="WARNING")))
         shutil.rmtree(self.cached_path)
         self.assertEqual(test_optional(self._get_args(index_repo=self.default_url)), 1)
         shutil.rmtree(self.cached_path)
@@ -110,7 +110,7 @@ class BackendTests(unittest.TestCase):
     def _get_args(self, index_repo):
         return argparse.Namespace(
             backend="none", args="", index_repo=index_repo, username="",
-            password="", cache=self.cached_path, log_level="WARNING")
+            password="", cache=self.cached_path, signoff=None, log_level="WARNING")
 
 
 if __name__ == "__main__":

--- a/modelforge/tests/test_index.py
+++ b/modelforge/tests/test_index.py
@@ -60,6 +60,7 @@ class GitIndexTests(unittest.TestCase):
         self.assertEqual(git_index.contents, self.default_index)
         self.assertEqual(git_index.models, self.default_index["models"])
         self.assertEqual(git_index.meta, self.default_index["meta"])
+        self.assertFalse(git_index.signoff)
 
     def test_init_fetch(self):
         ind.GitIndex(index_repo=self.default_url, cache=self.cached_path)
@@ -161,6 +162,10 @@ class GitIndexTests(unittest.TestCase):
             index_repo="https://github.com/src-d/models", cache=cached_path)
         self.assertEqual(git_index.repo, "src-d/models")
         self.assertEqual(git_index.cached_repo, "/tmp/modelforge-test-cache/cache/src-d/models")
+        self.clear()
+        fake_git.FakeRepo.reset(self.default_index)
+        git_index = ind.GitIndex(index_repo=self.default_url, cache=self.cached_path, signoff=True)
+        self.assertTrue(git_index.signoff)
 
     def test_remove(self):
         git_index = ind.GitIndex(index_repo=self.default_url, cache=self.cached_path)
@@ -280,8 +285,16 @@ class GitIndexTests(unittest.TestCase):
         git_index = ind.GitIndex(index_repo=self.default_url, cache=self.cached_path)
         git_index.upload("reset", {})
         self.assertTrue(fake_git.FakeRepo.added)
-        self.assertEqual(fake_git.FakeRepo.message, "Initialize a new Modelforge index")
+        self.assertEqual(
+            fake_git.FakeRepo.message, "Initialize a new Modelforge index")
         self.assertTrue(fake_git.FakeRepo.pushed)
+
+    def test_upload_dco(self):
+        git_index = ind.GitIndex(index_repo=self.default_url, cache=self.cached_path, signoff=True)
+        git_index.upload("reset", {})
+        self.assertEqual(
+            fake_git.FakeRepo.message, "Initialize a new Modelforge index\n\n"
+                                       "Signed-off-by: Travis CI User <travis@example.org>")
 
     def test_upload_bug(self):
         git_index = ind.GitIndex(index_repo=self.default_url, cache=self.cached_path)

--- a/modelforge/tests/test_main.py
+++ b/modelforge/tests/test_main.py
@@ -19,6 +19,7 @@ class MainTests(unittest.TestCase):
             self.assertTrue(hasattr(args, "cache"))
             self.assertTrue(hasattr(args, "username"))
             self.assertTrue(hasattr(args, "password"))
+            self.assertTrue(hasattr(args, "signoff"))
 
         def template_args(args):
             self.assertTrue(hasattr(args, "template_model"))


### PR DESCRIPTION
Reacting to this: https://github.com/src-d/models/pull/4 I've added DCO to the commit message. You can pass it as arguments with `committer-name` and `committer-email` flags, or simply define them in `modelforgecfg.py` or ENV variables like for other "annoying" parameters.