### PR TITLE
Manage no index or empty index case

### DIFF
--- a/modelforge/__main__.py
+++ b/modelforge/__main__.py
@@ -27,7 +27,7 @@ def main():
         p.add_argument("--username", default="",
                        help="Username for the Git repository with the index.")
         p.add_argument("--password", default="",
-                       help="Password for the Git repository with the index")
+                       help="Password for the Git repository with the index.")
         p.add_argument("--index-repo", default=None,
                        help="Url of the remote Git repository.")
         p.add_argument("--cache", default=None,

--- a/modelforge/backends.py
+++ b/modelforge/backends.py
@@ -45,7 +45,7 @@ def create_backend_noexc(log: logging.Logger, git_index: GitIndex, name: str=Non
         return None
 
 
-def supply_backend(optional=False):
+def supply_backend(optional: bool =False, init: bool=False):
     real_optional = False if callable(optional) else optional
 
     def supply_backend_inner(func):
@@ -54,7 +54,7 @@ def supply_backend(optional=False):
             log = logging.getLogger(func.__name__)
             try:
                 git_index = GitIndex(index_repo=args.index_repo, username=args.username,
-                                     password=args.password, cache=args.cache,
+                                     password=args.password, cache=args.cache, init=init,
                                      log_level=args.log_level)
             except ValueError:
                 return 1

--- a/modelforge/registry.py
+++ b/modelforge/registry.py
@@ -13,7 +13,7 @@ from modelforge.index import GitIndex
 from modelforge.meta import extract_model_meta
 
 
-@supply_backend
+@supply_backend(init=True)
 def initialize_registry(args: argparse.Namespace, backend: StorageBackend, log: logging.Logger):
     """
     Initialize the registry and the index.

--- a/modelforge/tests/fake_dulwich.py
+++ b/modelforge/tests/fake_dulwich.py
@@ -12,6 +12,10 @@ def clone(remote_url, cached_repo, checkout=True):
         raise HangupException
     if "bad-credentials" in remote_url:
         raise GitProtocolError
+    if "no-index" in remote_url:
+        raise FileNotFoundError
+    if "json" in remote_url:
+        raise ValueError
     os.makedirs(cached_repo, exist_ok=True)
     with open(os.path.join(cached_repo, "index.json"), "w") as _out:
         json.dump(FakeRepo.index, _out)

--- a/modelforge/tests/test_backends.py
+++ b/modelforge/tests/test_backends.py
@@ -65,13 +65,8 @@ class BackendTests(unittest.TestCase):
     def test_create_backend_invalid_args(self):
         backup = back.config.BACKEND_ARGS
         back.config.BACKEND_ARGS = "lalala"
-        success = True
-        try:
+        with self.assertRaises(ValueError):
             back.create_backend("Bar")
-            success = False
-        except ValueError:
-            pass
-        self.assertTrue(success)
         back.config.BACKEND_ARGS = backup
         backup = back.config.BACKEND_ARGS
         back.config.BACKEND_ARGS = ""

--- a/modelforge/tests/test_index.py
+++ b/modelforge/tests/test_index.py
@@ -104,6 +104,12 @@ class GitIndexTests(unittest.TestCase):
             ind.GitIndex(index_repo=self.default_url, password="no-username",
                          cache=self.cached_path)
 
+        with self.assertRaises(ValueError):
+            ind.GitIndex(index_repo="http://github.com/no-index", cache=self.cached_path)
+
+        with self.assertRaises(ValueError):
+            ind.GitIndex(index_repo="http://github.com/json", cache=self.cached_path)
+
     def test_init_variants(self):
         git_index = ind.GitIndex(
             index_repo="http://github.com/src-d/models", cache=self.cached_path)


### PR DESCRIPTION
Extracted from https://github.com/src-d/modelforge/pull/36 
Adds changes in the case where the index is either empty (meaning really empty, if it contains `{}` its fine) or non-existant in the repo. This means that there must be an index file in the repo at all time, even before init. If you want me to change this we will need to add some form of boolean so that during the initialization of the index we catche this error instead of aborting