### PR TITLE
[FIX] Remove index caching if backend is unused

### DIFF
--- a/doc/cmd.md
+++ b/doc/cmd.md
@@ -88,7 +88,8 @@ modelforge list --username user --password pass --index-repo https://github.com/
 ## Dump information about a model
 
 With this command you can get a dump of information concerning a specific model. The output of this
-command depends completely on the `dump` method of the model's class. 
+command depends completely on the `dump` method of the model's class. Naturally, if the model is 
+stored in your filesystem there is no need to specify backend or index arguments.
 
 - First (and only) positional argument: Path (if the model is stored on your filesystem), UUID or 
 URL of the model. 

--- a/modelforge/backends.py
+++ b/modelforge/backends.py
@@ -52,16 +52,15 @@ def supply_backend(optional: bool =False, init: bool=False):
         @wraps(func)
         def wrapped_supply_backend(args):
             log = logging.getLogger(func.__name__)
-            try:
-                git_index = GitIndex(index_repo=args.index_repo, username=args.username,
-                                     password=args.password, cache=args.cache, init=init,
-                                     signoff=args.signoff, log_level=args.log_level)
-            except ValueError:
-                return 1
-
             if real_optional and not getattr(args, "backend", False):
                 backend = None
             else:
+                try:
+                    git_index = GitIndex(index_repo=args.index_repo, username=args.username,
+                                         password=args.password, cache=args.cache, init=init,
+                                         signoff=args.signoff, log_level=args.log_level)
+                except ValueError:
+                    return 1
                 backend = create_backend_noexc(log, git_index, args.backend, args.args)
                 if backend is None:
                     return 1

--- a/modelforge/tests/test_backends.py
+++ b/modelforge/tests/test_backends.py
@@ -101,10 +101,7 @@ class BackendTests(unittest.TestCase):
         self.assertIsNone(test_optional(argparse.Namespace(
             index_repo=self.default_url, username="", password="", cache=self.cached_path,
             signoff=None, log_level="WARNING")))
-        shutil.rmtree(self.cached_path)
         self.assertEqual(test_optional(self._get_args(index_repo=self.default_url)), 1)
-        shutil.rmtree(self.cached_path)
-        self.tearDown()
         self.assertEqual(1, test_optional(self._get_args(index_repo="any_error_really")))
 
     def _get_args(self, index_repo):


### PR DESCRIPTION
Konst reminded me this flaw: the git based index being cloned for no reason when using `dump` with no backend, to simply get information from a model on local storage. I forgot to take out earlier, now it should be good