### PR TITLE
Fix extract_model_meta()

### DIFF
--- a/modelforge/meta.py
+++ b/modelforge/meta.py
@@ -84,7 +84,8 @@ def extract_model_meta(base_meta: dict, extra_meta: dict, model_url: str) -> dic
     del base_meta["model"]
     del base_meta["uuid"]
     meta["model"] = base_meta
-    meta["model"].update({k: extra_meta[k] for k in ("code", "datasets", "references", "tags")})
+    meta["model"].update({k: extra_meta[k] for k in ("code", "datasets", "references", "tags",
+                                                     "extra")})
     response = requests.get(model_url, stream=True)
     meta["model"]["size"] = humanize.naturalsize(int(response.headers["content-length"]))
     meta["model"]["source"] = model_url

--- a/modelforge/meta.py
+++ b/modelforge/meta.py
@@ -80,7 +80,9 @@ def extract_model_meta(base_meta: dict, extra_meta: dict, model_url: str) -> dic
     :param model_url: public URL of the model.
     :return: converted dict.
     """
-    meta = {"default": {"default": base_meta["uuid"], "description": base_meta["description"]}}
+    meta = {"default": {"default": base_meta["uuid"],
+                        "description": base_meta["description"],
+                        "code": extra_meta["code"]}}
     del base_meta["model"]
     del base_meta["uuid"]
     meta["model"] = base_meta

--- a/modelforge/meta.py
+++ b/modelforge/meta.py
@@ -90,6 +90,6 @@ def extract_model_meta(base_meta: dict, extra_meta: dict, model_url: str) -> dic
                                                      "extra")})
     response = requests.get(model_url, stream=True)
     meta["model"]["size"] = humanize.naturalsize(int(response.headers["content-length"]))
-    meta["model"]["source"] = model_url
+    meta["model"]["url"] = model_url
     meta["model"]["created_at"] = format_datetime(meta["model"]["created_at"])
     return meta

--- a/modelforge/tests/test_meta.py
+++ b/modelforge/tests/test_meta.py
@@ -65,7 +65,8 @@ class MetaTests(unittest.TestCase):
         self.assertDictEqual(
             model_meta, {
                 "default": {"default": "12345678-9abc-def0-1234-56789abcdef0",
-                            "description": "model_description"},
+                            "description": "model_description",
+                            "code": "model_code %s"},
                 "model": {"created_at": met.format_datetime(dt),
                           "code": "model_code %s",
                           "description": "model_description",

--- a/modelforge/tests/test_meta.py
+++ b/modelforge/tests/test_meta.py
@@ -77,7 +77,7 @@ class MetaTests(unittest.TestCase):
                           "references": [["any", "ref"]],
                           "size": "7 Bytes",
                           "series": "pga-2018",
-                          "source": "https://xxx",
+                          "url": "https://xxx",
                           "tags": ["one", "two"],
                           "version": [1, 0, 2],
                           "extra": {"feature": "value"}}})

--- a/modelforge/tests/test_meta.py
+++ b/modelforge/tests/test_meta.py
@@ -50,7 +50,8 @@ class MetaTests(unittest.TestCase):
             "datasets": [["any", "https://any"]],
             "description": "override",
             "references": [["any", "ref"]],
-            "tags": ["one", "two"]
+            "tags": ["one", "two"],
+            "extra": {"feature": "value"},
         }
 
         def route(url):
@@ -77,7 +78,8 @@ class MetaTests(unittest.TestCase):
                           "series": "pga-2018",
                           "source": "https://xxx",
                           "tags": ["one", "two"],
-                          "version": [1, 0, 2], }})
+                          "version": [1, 0, 2],
+                          "extra": {"feature": "value"}}})
 
 
 def get_path(name):


### PR DESCRIPTION
Bumbed into several issues with templates rendering while publishing new model.
Fixed `extract_model_meta()` in several places, now everything seems fine: managed to publish the new model succesfully, using this branch modelforge version. 
Fixed tests only for one case, didn't dig into the template rendering tests.