### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,11 @@ numpy==1.14.0
 scipy==1.0.0
 clint==0.5.1
 google-cloud-storage==1.2.0
-dulwich==0.19.5
+dulwich==0.19.11
 jinja2 ==2.10
 humanize==0.5.1
 python-dateutil==2.7.3
-requests==2.18.4
+requests==2.21.0
 pygtrie==2.3
 xxhash==1.2.0
 spdx==2.5.0

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
                       "numpy>=1.12,<2.0",
                       "scipy>=1.0,<2.0",
                       "clint>=0.5.0,<0.6",
-                      "google-cloud-storage>=1.2,<2.0",
+                      "google-cloud-storage>=1.2,<=1.2.0",
                       "dulwich>=0.19,<1.0",
                       "jinja2 >=2.0,<3.0",
                       "humanize>=0.5.0,<0.6",


### PR DESCRIPTION
Previous configuration had fatal conflicts.

P.S. Important:
- latest release of `google-cloud-storage` is `==1.14.0`
- we use `==1.2.0` in requirements and restrict to `<2.0` in `setup.py` (so the latest version **is accepted** in `setup.py`).

The problem is that the API we use was **incompatibly** changed somewhere in-between. So probably at some point we'll have to update that too to keep up.
Right now it's left as it is, because it works when the strict requirements are satisfied.

But i was held up by this exact issue after installing modelforge through pip, so probably we should do smth already.