### PR TITLE
Handle empty strings in merge_strings and split_strings

### DIFF
--- a/modelforge/model.py
+++ b/modelforge/model.py
@@ -478,6 +478,10 @@ def merge_strings(list_of_strings: Union[List[str], Tuple[str]]) -> dict:
     """
     if not isinstance(list_of_strings, (tuple, list)):
         raise TypeError("list_of_strings must be either a tuple or a list")
+    if len(list_of_strings) == 0:
+        return {"strings": numpy.array([], dtype="S1"),
+                "lengths": numpy.array([], dtype=int),
+                "str": None}
     with_str = not isinstance(list_of_strings[0], bytes)
     if with_str:
         if not isinstance(list_of_strings[0], str):
@@ -505,10 +509,13 @@ def split_strings(subtree: dict) -> List[str]:
     :param subtree: The dict with "strings" and "lengths".
     :return: :class:`list` of :class:`str`-s or :class:`bytes`.
     """
-    strings = subtree["strings"][0]
+    strings = subtree["strings"]
+    lengths = subtree["lengths"]
+    if len(lengths) == 0 and len(strings) == 0:
+        return []
+    strings = strings[0]
     if subtree.get("str", True):
         strings = strings.decode("utf-8")
-    lengths = subtree["lengths"]
     result = [None] * lengths.shape[0]
     offset = 0
     for i, l in enumerate(lengths):

--- a/modelforge/tests/test_model.py
+++ b/modelforge/tests/test_model.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 import asdf
 import numpy
+from numpy.testing import assert_array_equal
 from scipy.sparse import csr_matrix
 
 from modelforge import configuration, storage_backend
@@ -443,6 +444,15 @@ class ModelTests(unittest.TestCase):
 
 class SerializationTests(unittest.TestCase):
     DOCFREQ_PATH = "test.asdf"
+
+    def test_empty_split_and_merge(self):
+        strings = []
+        merged = merge_strings(strings)
+        assert_array_equal(merged["strings"], numpy.array([], dtype="S1"))
+        assert_array_equal(merged["lengths"], numpy.array([], dtype=int))
+        self.assertIsNone(merged["str"])
+        strings_restored = split_strings(merged)
+        self.assertEqual(strings, strings_restored)
 
     def test_merge_strings(self):
         strings = ["a", "bc", "def"]


### PR DESCRIPTION
Such a situation can happen when we are trying to save an empty model for IdTyposAnalyer because there are no identifiers were found in the file. (https://github.com/src-d/style-analyzer/blob/master/lookout/style/typos/analyzer.py#L319-L320)