### PR TITLE
Low hanging fruits

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length=99
-ignore=B008,E121,E123,E126,E203,E226,E24,E704,E731,W503,W504,D100,D105,D200,D202,D301,D402
+ignore=B008,E121,E123,E126,E226,E24,E704,W503,W504,D100,D200,D301,D402
 inline-quotes="
 import-order-style=appnexus
 application-package-names=modelforge

--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length=99
-ignore=B008,E121,E123,E126,E226,E24,E704,W503,W504,D100,D200,D301,D402
+ignore=B008,E121,E123,E126,E203,E226,E24,E704,E731,W503,W504,D100,D105,D200,D202,D301,D402
 inline-quotes="
 import-order-style=appnexus
 application-package-names=modelforge

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# VSCode
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ADD requirements.txt setup.py package/
 ADD modelforge package/modelforge

--- a/doc/CODE_OF_CONDUCT.md
+++ b/doc/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# Code of Conduct
+# CODE OF CONDUCT
 
 ## Our Pledge
 
@@ -49,4 +49,3 @@ Project maintainers who do not follow or enforce the Code of Conduct in good fai
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 1.4, available at [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html)
-

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing
+# CONTRIBUTING
 
 Modelforge project is [Apache 2.0 licensed](../LICENSE) and accepts contributions via GitHub pull requests. This document outlines some of the conventions on development workflow, commit message formatting, contact points, and other resources to make it easier to get your contribution accepted.
 
@@ -23,12 +23,12 @@ The official support channels, for both users and contributors, are:
 
 Pull Requests \(PRs\) are the main and exclusive way to contribute to the official Modelforge project. In order for a PR to be accepted it needs to pass a list of requirements:
 
-* Code coverage does not decrease.
+* Code Coverage does not decrease.
 * All the tests pass.
 * The code is formatted according to [![PEP8](https://img.shields.io/badge/code%20style-pep8-orange.svg)](https://www.python.org/dev/peps/pep-0008/).
 * If the PR is a bug fix, it has to include a new unit test that fails before the patch is merged.
 * If the PR is a new feature, it has to come with a suite of unit tests, that tests the new functionality.
-* In any case, all the PRs have to pass the personal evaluation of at least one of the [maintainers](maintainers.md).
+* In any case, all the PRs have to pass the personal evaluation of at least one of the [maintainers](MAINTAINERS).
 
 ### Format of the commit message
 
@@ -41,4 +41,3 @@ Fix a bug
 ```
 
 Every commit details should describe what was changed, under which context and, if applicable, the GitHub issue it relates to.
-

--- a/doc/MAINTAINERS
+++ b/doc/MAINTAINERS
@@ -1,0 +1,2 @@
+Vadim Markovtsev <vadim@sourced.tech> (@vmarkovtsev)
+Romain Keramitas <r.keramitas@gmail.com> (@r0mainK)

--- a/doc/maintainers.md
+++ b/doc/maintainers.md
@@ -1,3 +1,0 @@
-# List of Modelforge maintainers
-
-* Vadim Markovtsev \<vadim@sourced.tech\>

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,4 +1,3 @@
-black==19.10b0
 flake8==3.5.0
 flake8-bugbear==18.8.0
 flake8-docstrings==1.3.1

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,7 +1,7 @@
+black==19.10b0
 flake8==3.5.0
 flake8-bugbear==18.8.0
-flake8-docstrings==1.3.0
+flake8-docstrings==1.3.1
 flake8-import-order==0.18
 flake8-quotes==1.0.0
 flake8-per-file-ignores==0.6
-pydocstyle==3.0.0 # remove when https://github.com/PyCQA/pydocstyle/issues/375 is solved

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,20 @@
 from importlib.machinery import SourceFileLoader
-import os
+from pathlib import Path
 
 from setuptools import find_packages, setup
 
-basedir = os.path.dirname(__file__)
+root = Path(__file__).parent
 modelforge = SourceFileLoader(
-    "modelforge", os.path.join(basedir, "modelforge", "version.py")).load_module()
-with open(os.path.join(basedir, "README.md"), encoding="utf-8") as f:
+    "modelforge", (root / "modelforge" / "version.py").as_posix()
+).load_module()
+with (root / "README.md").open(encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
     name="modelforge",
-    description="APIs and tools to work with abstract \"models\" - files "
-                "with numpy arrays and metadata. It is possible to publish "
-                "models, list them. There is a built-in cache. Storage has backends.",
+    description="APIs and tools to work with abstract 'models' - files "
+    "with numpy arrays and metadata. It is possible to publish "
+    "models, list them. There is a built-in cache. Storage has backends.",
     long_description=long_description,
     long_description_content_type="text/markdown",
     version=modelforge.__version__,
@@ -23,41 +24,45 @@ setup(
     url="https://github.com/src-d/modelforge",
     download_url="https://github.com/src-d/modelforge",
     packages=find_packages(exclude=("modelforge.tests",)),
-    keywords=["model", "git", "asdf", "gcs", "google cloud storage",
-              "machine learning", "registry"],
-    install_requires=["asdf>=2.4.0,<2.5",
-                      "lz4>=1.0,<3.0",
-                      "numpy>=1.12,<2.0",
-                      "scipy>=1.0,<2.0",
-                      "clint>=0.5.0,<0.6",
-                      "google-cloud-storage>=1.2,<=1.2.0",
-                      # dulwich does not specify an upper version constraint for urllib3
-                      # so we may end up with a conflict otherwise
-                      "urllib3<1.25",
-                      "requests>=2.0,<3.0",
-                      "dulwich>=0.19,<1.0",
-                      "jinja2>=2.10.1,<3.0",
-                      "humanize>=0.5.0,<0.6",
-                      "python-dateutil>=2.0,<3.0",
-                      "typing;python_version<'3.5'",
-                      "pygtrie>=1.0,<3.0",
-                      "xxhash>=1.0,<2.0",
-                      "spdx>=2.0,<3.0"],
-    entry_points={
-        "console_scripts": ["modelforge=modelforge.__main__:main"],
-    },
-    package_data={"": ["LICENSE", "README.md"],
-                  "modelforge": ["templates/*"], },
+    keywords=[
+        "model",
+        "git",
+        "asdf",
+        "gcs",
+        "google cloud storage",
+        "machine learning",
+        "registry",
+    ],
+    install_requires=[
+        "asdf>=2.4.0,<2.5",
+        "lz4>=1.0,<3.0",
+        "numpy>=1.12,<2.0",
+        "scipy>=1.0,<2.0",
+        "clint>=0.5.0,<0.6",
+        "google-cloud-storage>=1.2,<=1.2.0",
+        # dulwich does not specify an upper version constraint for urllib3
+        # so we may end up with a conflict otherwise
+        "urllib3<1.25",
+        "requests>=2.0,<3.0",
+        "dulwich>=0.19,<1.0",
+        "jinja2>=2.10.1,<3.0",
+        "humanize>=0.5.0,<0.6",
+        "python-dateutil>=2.0,<3.0",
+        "typing;python_version<'3.5'",
+        "pygtrie>=1.0,<3.0",
+        "xxhash>=1.0,<2.0",
+        "spdx>=2.0,<3.0",
+    ],
+    entry_points={"console_scripts": ["modelforge=modelforge.__main__:main"]},
+    package_data={"": ["LICENSE", "README.md"], "modelforge": ["templates/*"]},
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Environment :: Console",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
-        "Topic :: Software Development :: Libraries"
-    ]
+        "Topic :: Software Development :: Libraries",
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Software Development :: Libraries",
     ],
 )


### PR DESCRIPTION
1. Added a couple PEP8 exceptions: 
- E203: 
- E731: sometimes we want lambda expressions
- D105: magic method docstrings not necessarily required
- D202: causes conflicts if you define a function in a function

2. VSCode in gitignore for custom config

3. Setup.py: removed python 3.5/3.4, using pathlib, corrected formatting

4. Swith to Ubuntu 18.04 in Dockerfile

5. Fix linting requirements, add black to it for pretty formatting

6. Add myself MAINTAINERS (I think that may be why I can't add you as a reviewer ?) file and rename it, rename CODE OF CONDUCT and CONTRIBUTING guidelines + remove trailing line and smalll typo. I don't know why this repo is the only one which does not have these files captalized